### PR TITLE
change name from vtta-party to party-overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ Along with some minor bugfixes, I switched from HTML tooltips to rendered PIXI t
 
 ## [2.1.0] Loads of Love
 
-This release is dedicated to Tim, the patient. Without you poking me all the time I probably would have trashed vtta-party someday because I seem to be the only one finding it not that useful ;) At least the code base is now up to some standards again.
+This release is dedicated to Tim, the patient. Without you poking me all the time I probably would have trashed party-overview someday because I seem to be the only one finding it not that useful ;) At least the code base is now up to some standards again.
 
 Minor new features:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# (loefd-)vtta-party
+# party-overview
 
-This is a League of Extraordinary Foundry Developers stewarded module fork. The original author indicated after some time of this not being updated that he was open to having a new maintainer and so we stepped in to steward it. In the process we made the call to remove some functionality as it was badly outdated and superceded by other, newer modules.
+This is a League of Extraordinary Foundry Developers stewarded module fork of [vtta-party](https://github.com/VTTAssets/vtta-party). The original author indicated after some time of this not being updated that he was open to having a new maintainer and so we stepped in to steward it. In the process we made the call to remove some functionality as it was badly outdated and superceded by other, newer modules.
 
 The plan at the moment is to remove the Tooltip functionality from the module, keeping instead only the party overview Application. In our opinion, the [Token Tooltip Alt](https://github.com/bmarian/token-tooltip-alt) module enables all of its functionality and more.
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -1,8 +1,8 @@
 {
-  "vtta-party.EnablePlayerAccess.Name": "Dürfen Spieler die Übersicht nutzen?",
-  "vtta-party.EnablePlayerAccess.Hint": "Erlaubt oder verhindert, dass Spieler ebenfalls die Übersicht nutzen können, um die Statistiken aller Spieler auf der gerade aktiven Szene zu überblicken.",
-  "vtta-party.EnableTooltip.Name": "Tooltips aktivieren?",
-  "vtta-party.EnableTooltip.Hint": "Aktiviert oder deaktiviert Tooltips, die beim Schweben über Tokens angezeigt werden.",
-  "vtta-party.EnablePlayerAccessTooltip.Name": "Tooltips für Spieler aktivieren?",
-  "vtta-party.EnablePlayerAccessTooltip.Hint": "Aktiviert oder deaktiviert Tooltips für Spieler, jedoch nur für ihre eigenen Tokens"
+  "party-overview.EnablePlayerAccess.Name": "Dürfen Spieler die Übersicht nutzen?",
+  "party-overview.EnablePlayerAccess.Hint": "Erlaubt oder verhindert, dass Spieler ebenfalls die Übersicht nutzen können, um die Statistiken aller Spieler auf der gerade aktiven Szene zu überblicken.",
+  "party-overview.EnableTooltip.Name": "Tooltips aktivieren?",
+  "party-overview.EnableTooltip.Hint": "Aktiviert oder deaktiviert Tooltips, die beim Schweben über Tokens angezeigt werden.",
+  "party-overview.EnablePlayerAccessTooltip.Name": "Tooltips für Spieler aktivieren?",
+  "party-overview.EnablePlayerAccessTooltip.Hint": "Aktiviert oder deaktiviert Tooltips für Spieler, jedoch nur für ihre eigenen Tokens"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,10 +1,10 @@
 {
-  "vtta-party.EnablePlayerAccess.Name": "Grant Players access to the overview?",
-  "vtta-party.EnablePlayerAccess.Hint": "Allows or disallows players to access the Party window to see the stats every player on the current scene, too",
-  "vtta-party.EnableTooltip.Name": "Enable tooltips?",
-  "vtta-party.EnableTooltip.Hint": "Enables or disables tooltips when hovering over tokens",
-  "vtta-party.EnablePlayerAccessTooltip.Name": "Enable tooltips for players?",
-  "vtta-party.EnablePlayerAccessTooltip.Hint": "Enables or disables tooltips for players, but only for tokens they own.",
-  "vtta-party.TooltipFontSizeInPixels.Name": "Set the font size for tooltips in pixels.",
-  "vtta-party.TooltipFontSizeInPixels.Hint": "Default: 14"
+  "party-overview.EnablePlayerAccess.Name": "Grant Players access to the overview?",
+  "party-overview.EnablePlayerAccess.Hint": "Allows or disallows players to access the Party window to see the stats every player on the current scene, too",
+  "party-overview.EnableTooltip.Name": "Enable tooltips?",
+  "party-overview.EnableTooltip.Hint": "Enables or disables tooltips when hovering over tokens",
+  "party-overview.EnablePlayerAccessTooltip.Name": "Enable tooltips for players?",
+  "party-overview.EnablePlayerAccessTooltip.Hint": "Enables or disables tooltips for players, but only for tokens they own.",
+  "party-overview.TooltipFontSizeInPixels.Name": "Set the font size for tooltips in pixels.",
+  "party-overview.TooltipFontSizeInPixels.Hint": "Default: 14"
 }

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1,10 +1,10 @@
 {
-  "vtta-party.EnablePlayerAccess.Name": "Permita acesso do panorama aos jogadores?",
-  "vtta-party.EnablePlayerAccess.Hint": "Permita ou bloqueie aos jogadores acesso a janela de grupo para ver os status de cada jogador em cena.",
-  "vtta-party.EnableTooltip.Name": "Habilitar Dicas?",
-  "vtta-party.EnableTooltip.Hint": "Habilitar ou desabilitar dicas quando sobrepor os tokens",
-  "vtta-party.EnablePlayerAccessTooltip.Name": "Habilitar dicas para jogadores?",
-  "vtta-party.EnablePlayerAccessTooltip.Hint": "Habilitar ou desabilitar dicas aos jogadores, mas somente para seus proprios tokens.",
-  "vtta-party.TooltipFontSizeInPixels.Name": "Defina o tamanho da fonte em pixels:",
-  "vtta-party.TooltipFontSizeInPixels.Hint": "Padrão: 14"
+  "party-overview.EnablePlayerAccess.Name": "Permita acesso do panorama aos jogadores?",
+  "party-overview.EnablePlayerAccess.Hint": "Permita ou bloqueie aos jogadores acesso a janela de grupo para ver os status de cada jogador em cena.",
+  "party-overview.EnableTooltip.Name": "Habilitar Dicas?",
+  "party-overview.EnableTooltip.Hint": "Habilitar ou desabilitar dicas quando sobrepor os tokens",
+  "party-overview.EnablePlayerAccessTooltip.Name": "Habilitar dicas para jogadores?",
+  "party-overview.EnablePlayerAccessTooltip.Hint": "Habilitar ou desabilitar dicas aos jogadores, mas somente para seus proprios tokens.",
+  "party-overview.TooltipFontSizeInPixels.Name": "Defina o tamanho da fonte em pixels:",
+  "party-overview.TooltipFontSizeInPixels.Hint": "Padrão: 14"
 }

--- a/module.json
+++ b/module.json
@@ -25,7 +25,7 @@
   ],
   "systems": ["dnd5e", "pf2e", "wfrp4e", "swade"],
   "esmodules": ["./src/index.js"],
-  "styles": ["./style/module-settings.css", "./style/vtta.css", "./style/module-settings.css"],
+  "styles": ["./style/module-settings.css", "./style/party-overview.css", "./style/module-settings.css"],
   "packs": [],
   "url": "http://github.com/League-of-Foundry-Developers/party-overview",
   "bugs": "http://github.com/League-of-Foundry-Developers/party-overview/issues",

--- a/module.json
+++ b/module.json
@@ -1,5 +1,5 @@
 {
-  "name": "vtta-party",
+  "name": "party-overview",
   "title": "Party Overview",
   "description": "Provides an instant overview about vital stats of the players active in the current scene",
   "version": "2.3.3",
@@ -27,7 +27,8 @@
   "esmodules": ["./src/index.js"],
   "styles": ["./style/module-settings.css", "./style/vtta.css", "./style/module-settings.css"],
   "packs": [],
-  "url": "http://github.com/League-of-Foundry-Developers/vtta-party",
-  "manifest": "http://github.com/League-of-Foundry-Developers/vtta-party/releases/latest/download/module.json",
-  "download": "http://github.com/League-of-Foundry-Developers/vtta-party/releases/latest/download/module.zip"
+  "url": "http://github.com/League-of-Foundry-Developers/party-overview",
+  "bugs": "http://github.com/League-of-Foundry-Developers/party-overview/issues",
+  "manifest": "http://github.com/League-of-Foundry-Developers/party-overview/releases/latest/download/module.json",
+  "download": "http://github.com/League-of-Foundry-Developers/party-overview/releases/latest/download/module.zip"
 }

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -128,9 +128,9 @@ class App extends Application {
       width: 500,
       height: 300,
       resizable: true,
-      title: "VTTA Party",
-      template: `/modules/vtta-party/templates/${game.system.id}.hbs`,
-      classes: ["vtta", "party", game.system.id],
+      title: "Party Overview",
+      template: `/modules/party-overview/templates/${game.system.id}.hbs`,
+      classes: ["party-overview", game.system.id],
       tabs: [
         {
           navSelector: ".tabs",
@@ -354,8 +354,8 @@ class App extends Application {
       console.log("Tooltip not initialized");
       return;
     }
-    if (!game.settings.get("vtta-party", "EnableTooltip")) return;
-    if (!game.user.isGM && !game.settings.get("vtta-party", "EnablePlayerAccessTooltip")) return;
+    if (!game.settings.get("party-overview", "EnableTooltip")) return;
+    if (!game.user.isGM && !game.settings.get("party-overview", "EnablePlayerAccessTooltip")) return;
     if (!token || !token.actor) return;
 
     if (!hovered) {

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -8,7 +8,7 @@ const DISPLAY_MODE = {
 
 const SIMPLE_SYTEMS = ['swade'];
 
-class App extends Application {
+class PartyOverviewApp extends Application {
   constructor(options) {
     super(options);
 
@@ -494,4 +494,4 @@ class App extends Application {
   }
 }
 
-export default App;
+export default PartyOverviewApp;

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 const config = {
-  name: "VTTA Party",
-  version: "2.3.0",
+  name: "Party Overview",
+  version: "2.3.4",
 };
 
 export default config;

--- a/src/index.js
+++ b/src/index.js
@@ -57,15 +57,15 @@ Hooks.once("init", () => {
     },
   ].forEach((setting) => {
     let options = {
-      name: game.i18n.localize(`vtta-party.${setting.name}.Name`),
-      hint: game.i18n.localize(`vtta-party.${setting.name}.Hint`),
+      name: game.i18n.localize(`party-overview.${setting.name}.Name`),
+      hint: game.i18n.localize(`party-overview.${setting.name}.Hint`),
       scope: setting.scope,
       config: true,
       default: setting.default,
       type: setting.type,
     };
     if (setting.choices) options.choices = setting.choices;
-    game.settings.register("vtta-party", setting.name, options);
+    game.settings.register("party-overview", setting.name, options);
   });
 });
 
@@ -75,11 +75,11 @@ Hooks.on("ready", () => {
 });
 
 Hooks.on("renderActorDirectory", (app, html, data) => {
-  if (!game.user.isGM && !game.settings.get("vtta-party", "EnablePlayerAccess"))
+  if (!game.user.isGM && !game.settings.get("party-overview", "EnablePlayerAccess"))
     return;
 
   let button = $(
-    `<button id="vtta-party-button" class="${game.system.id}"><i class="fas fa-info-circle"></i></button>`
+    `<button id="party-overview-button" class="${game.system.id}"><i class="fas fa-info-circle"></i></button>`
   );
   button.on("click", (e) => {
     party.render(true);

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import config from "./config.js";
-import App from "./app/index.js";
+import PartyOverviewApp from "./app/index.js";
 import Tooltip from "./tooltip/index.js";
 
 Handlebars.registerHelper("ifEquals", function (arg1, arg2, options) {
@@ -26,7 +26,7 @@ Hooks.on("canvasReady", (_) => {
 });
 
 Hooks.once("init", () => {
-  party = new App();
+  party = new PartyOverviewApp();
   /**
    * Register settings
    */
@@ -71,7 +71,7 @@ Hooks.once("init", () => {
 
 Hooks.on("ready", () => {
   if (party) party.update();
-  else party = new App();
+  else party = new PartyOverviewApp();
 });
 
 Hooks.on("renderActorDirectory", (app, html, data) => {

--- a/src/tooltip/index.js
+++ b/src/tooltip/index.js
@@ -123,7 +123,7 @@ class Tooltip extends CanvasLayer {
   }
 
   getTooltipFontSizeInPixelsFromGameSettings() {
-    return game.settings.get("vtta-party", "TooltipFontSizeInPixels");
+    return game.settings.get("party-overview", "TooltipFontSizeInPixels");
   }
   
   /**

--- a/style/party-overview.css
+++ b/style/party-overview.css
@@ -1,30 +1,30 @@
-div.vtta.party nav.tabs {
+div.party-overview nav.tabs {
   display: flex;
   flex-direction: row;
 }
 
-div.vtta.party nav li {
+div.party-overview nav li {
   display: inline-block;
   list-style-type: none;
 }
 
-div.vtta.party nav .item {
+div.party-overview nav .item {
   color: gray;
 }
 
-div.vtta.party nav .item.active {
+div.party-overview nav .item.active {
   color: black;
   border-bottom: 2px solid #782e22;
   text-shadow: none;
 }
 
-#vtta-party-button {
+#party-overview-button {
   display: block;
   flex: 0 0 32px;
   height: 32px;
 }
 
-div.vtta.party .table-row {
+div.party-overview .table-row {
   display: flex;
   display: -webkit-flex;
   flex-direction: row;
@@ -36,23 +36,23 @@ div.vtta.party .table-row {
   width: 100%;
 }
 
-div.vtta.party .table-row span.note {
+div.party-overview .table-row span.note {
   font-size: 0.6rem;
   color: green;
   font-weight: bold;
   line-height: 18pt;
 }
 
-div.vtta.party .table-row span.adjusted {
+div.party-overview .table-row span.adjusted {
   color: green;
   font-weight: bold;
 }
 
-div.vtta.party .table-row:nth-child(2n) {
+div.party-overview .table-row:nth-child(2n) {
   background-color: rgb(228, 228, 228);
 }
 
-div.vtta.party .table-row .text {
+div.party-overview .table-row .text {
   margin: auto;
   flex-grow: 2;
   overflow: hidden;
@@ -62,17 +62,17 @@ div.vtta.party .table-row .text {
   flex-basis: 50px;
 }
 
-div.vtta.party .table-row .text.icon {
+div.party-overview .table-row .text.icon {
   text-align: center;
 }
 
-div.vtta.party .table-row .text.background {
+div.party-overview .table-row .text.background {
   white-space: pre-wrap;
   text-align: left;
   vertical-align: top;
 }
 
-div.vtta.party .table-row .num {
+div.party-overview .table-row .num {
   margin: auto;
   text-align: center;
   flex-basis: 50px;
@@ -80,7 +80,7 @@ div.vtta.party .table-row .num {
   flex-shrink: 1;
 }
 
-div.vtta.party .table-row .button {
+div.party-overview .table-row .button {
   margin: auto;
   text-align: center;
   flex-basis: 70px;
@@ -92,20 +92,20 @@ div.vtta.party .table-row .button {
   * General good-look styles, not mandatory.
   */
 
-div.vtta.party .table-row {
+div.party-overview .table-row {
   border-bottom: 1px solid rgb(190, 190, 190);
   border-collapse: collapse;
   padding: 4px;
 }
 
-div.vtta.party .table-row.header {
+div.party-overview .table-row.header {
   font-weight: bold;
 }
 
-div.vtta.party.wfrp4e .table-row .button {
+div.party-overview.wfrp4e .table-row .button {
   margin-right: 6px;
 }
-div.vtta.party.wfrp4e .table-row .button button {
+div.party-overview.wfrp4e .table-row .button button {
   margin: 0px 5px 6px 5px !important;
   padding: 2px 0px 0px 0px;
   height: 34px;
@@ -123,10 +123,10 @@ div.vtta.party.wfrp4e .table-row .button button {
   text-shadow: 0px 0px 1px #00000063;
 }
 
-div.vtta.party.wfrp4e .table-row:nth-child(2n) {
+div.party-overview.wfrp4e .table-row:nth-child(2n) {
   background-color: rgba(228, 228, 228, 0.34);
 }
-#vtta-party-button.wfrp4e {
+#party-overview-button.wfrp4e {
   display: block;
   flex: 0 0 32px;
   height: 32px;


### PR DESCRIPTION
Changes name in a whole lotta places. Removes `.vtta` as well. This will cause a hard break from any previously installed users (also will cause you to rename your development folder or symlink in your module dir)