### PR TITLE
Fixed error if token lacks languages (familiar in PF2E)

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -55,7 +55,7 @@ class PartyOverviewApp extends Application {
       actors = actors.map(actor => {
         return {
           ...actor,
-          languages: languages.map(language => actor.languages && actor.languages.includes(language)),
+          languages: (actor.languages?(languages.map(language => actor.languages && actor.languages.includes(language))):[])
         };
       });
       totalCurrency = actors.reduce(
@@ -229,7 +229,7 @@ class PartyOverviewApp extends Application {
         },
 
         // details
-        languages: data.traits.languages.value.map(code => CONFIG.PF2E.languages[code]),
+	      languages: (data.traits.languages?(data.traits.languages.value.map(code => CONFIG.PF2E.languages[code])):[]),
       };
     }
 


### PR DESCRIPTION
The familiar actor in PF2E lacks a languages node.  This caused Party Overview to crash if the familiar was player owned.  Put a fix in to null languages for actors that lack them.